### PR TITLE
misc: Add pre-commit as a CI test run on the PRs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -108,3 +108,16 @@ repos:
             language: system
             stages: [commit-msg]
             description: Adds Change-ID to the commit message. Needed by Gerrit.
+
+
+ci:
+    autofix_commit_msg: |
+        misc: Auto fixes from pre-commit hooks
+
+        For more information, see https://pre-commit.ci
+    autofix_prs: true
+    autoupdate_branch: develop
+    autoupdate_commit_msg: 'misc: Autoupdate for pre-commit'
+    autoupdate_schedule: weekly
+    skip: []
+    submodules: false


### PR DESCRIPTION
Via a GitHub App the pre-commit tests checks will run and if fixes are required to the PR, these will be automatically applied as a commit to the PR.

https://pre-commit.ci

Change-Id: Ib8c4e312cc1781a6d4cecae7fde15a86f620fb28